### PR TITLE
Add new 'properties' validator which recurses into object.

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -225,6 +225,145 @@ describe("validate", function() {
         error: "error"
       }]);
     });
+
+    it("handles one level deep objects with missing content", function() {
+      var attributes = {
+        address: {
+        }
+      };
+
+      var constraints = {
+        address: {
+          properties: {
+            home: {
+              fail: true
+            }
+          }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address.home",
+        error: "error"
+      }]);
+    });
+
+    it("handles two level deep objects with missing content", function() {
+      var attributes = {
+        address: {
+        }
+      };
+
+      var constraints = {
+        address: {
+          pass: true,
+          properties: {
+            home: {
+              properties: {
+                postal_code: { fail: true }
+              }
+            }
+          }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address",
+        error: undefined
+      }]);
+    });
+
+    it("handles objects with missing content", function() {
+      var attributes = {
+        address: {
+        }
+      };
+
+      var constraints = {
+        address: {
+          pass: true,
+          properties: {
+            home: {
+              properties: {
+                postal_code: {
+                  pass: true
+                }
+              }
+            },
+            work: {
+              fail: true
+            }
+          }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address",
+        error: undefined
+      }, {
+        attribute: "address.work",
+        error: 'error'
+      }]);
+    });
+
+    it("handles objects with extra attributes", function() {
+      var attributes = {
+        address: {
+          school: {}
+        }
+      };
+
+      var constraints = {
+        address: {
+          properties: { }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address.school",
+        error: "was not expected"
+      }]);
+    });
+
+    it("handles objects with extra attributes two levels deep", function() {
+      var attributes = {
+        address: {
+          work: {
+            number: 42
+          }
+        }
+      };
+
+      var constraints = {
+        address: {
+          properties: {
+            work: {
+              properties: { }
+            }
+          }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address.work.number",
+        error: "was not expected"
+      }]);
+    });
   });
 
   describe("processValidationResults", function() {

--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -143,6 +143,88 @@ describe("validate", function() {
       validate.runValidations({}, {name: {pass: false}, email: {pass: null}}, {});
       expect(pass).not.toHaveBeenCalled();
     });
+
+    it("validates objects nested one level deep", function() {
+      fail.andReturn("error");
+
+      var attributes = {
+        home: {
+          postal_code: "94101"
+        }
+      };
+
+      var constraints = {
+        home: {
+          properties: {
+            postal_code: { pass: true },
+          },
+          fail: true
+        }
+      };
+
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "home",
+        error: "error"
+      }, {
+        attribute: "home.postal_code",
+        error: undefined
+      }]);
+    });
+
+    it("validates objects nested two levels deep", function() {
+      var attributes = {
+        address: {
+          home: {
+            postal_code: "94101"
+          },
+          work: {
+            postal_code: "94301"
+          }
+        }
+      };
+
+      var constraints = {
+        address: {
+          pass: true,
+          properties: {
+            home: {
+              properties: {
+                postal_code: { pass: true },
+              },
+              fail: true
+            },
+            work: {
+              properties: {
+                postal_code: { fail: true },
+              },
+              pass: true
+            }
+          }
+        }
+      };
+
+      fail.andReturn("error");
+      var result = validate.runValidations(attributes, constraints, {});
+
+      expect(result).toHaveItems([{
+        attribute: "address",
+        error: undefined
+      }, {
+        attribute: "address.home",
+        error: "error"
+      }, {
+        attribute: "address.home.postal_code",
+        error: undefined
+      }, {
+        attribute: "address.work",
+        error: undefined
+      }, {
+        attribute: "address.work.postal_code",
+        error: "error"
+      }]);
+    });
   });
 
   describe("processValidationResults", function() {

--- a/specs/validators/properties-spec.js
+++ b/specs/validators/properties-spec.js
@@ -1,0 +1,194 @@
+describe('validator.properties', function() {
+  beforeEach(function() {
+    fail = jasmine.createSpy('failValidator').andReturn("my error");
+    pass = jasmine.createSpy('passValidator');
+    validate.validators.pass = pass;
+    validate.validators.fail = fail;
+  });
+
+  afterEach(function() {
+    delete validate.validators.fail;
+    delete validate.validators.fail2;
+    delete validate.validators.pass;
+    delete validate.validators.pass2;
+  });
+
+  it("validates objects nested one level deep", function() {
+    var attributes = {
+      home: {
+        postal_code: "94101"
+      }
+    };
+
+    var constraints = {
+      home: {
+        properties: {
+          postal_code: { pass: true },
+        },
+        fail: true
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "home",
+      error: "my error"
+    }, {
+      attribute: "home.postal_code",
+      error: undefined
+    }]);
+  });
+
+  it("validates objects nested two levels deep", function() {
+    var attributes = {
+      address: {
+        home: {
+          postal_code: "94101"
+        },
+        work: {
+          postal_code: "94301"
+        }
+      }
+    };
+
+    var constraints = {
+      address: {
+        pass: true,
+        properties: {
+          home: {
+            properties: {
+              postal_code: { pass: true },
+            },
+            fail: true
+          },
+          work: {
+            properties: {
+              postal_code: { fail: true },
+            },
+            pass: true
+          }
+        }
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "address",
+      error: undefined
+    }, {
+      attribute: "address.home",
+      error: "my error"
+    }, {
+      attribute: "address.home.postal_code",
+      error: undefined
+    }, {
+      attribute: "address.work",
+      error: undefined
+    }, {
+      attribute: "address.work.postal_code",
+      error: "my error"
+    }]);
+  });
+
+  it("runs validations on missing sub-objects", function() {
+    var attributes = {
+      address: {
+      }
+    };
+
+    var constraints = {
+      address: {
+        properties: {
+          home: {
+            fail: true
+          }
+        }
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "address.home",
+      error: "my error"
+    }]);
+  });
+
+  it("doesn't try to descend into missing sub-objects", function() {
+    var attributes = {
+      address: {
+      }
+    };
+
+    var constraints = {
+      address: {
+        pass: true,
+        properties: {
+          home: {
+            properties: {
+              postal_code: { fail: true }
+            }
+          }
+        }
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "address",
+      error: undefined
+    }]);
+  });
+
+  it("complains about objects with extra attributes", function() {
+    var attributes = {
+      address: {
+        school: {}
+      }
+    };
+
+    var constraints = {
+      address: {
+        properties: { }
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "address.school",
+      error: "was not expected"
+    }]);
+  });
+
+  it("complains about objects with extra attributes two levels deep", function() {
+    var attributes = {
+      address: {
+        work: {
+          number: 42
+        }
+      }
+    };
+
+    var constraints = {
+      address: {
+        properties: {
+          work: {
+            properties: { }
+          }
+        }
+      }
+    };
+
+    var result = validate.runValidations(attributes, constraints, {});
+
+    expect(result).toHaveItems([{
+      attribute: "address.work.number",
+      error: "was not expected"
+    }]);
+  });
+});
+


### PR DESCRIPTION
Implement support for nested objects (#7).

The approach I took was to create a `properties` validator which recursively invokes `runValidations`.

A way to do validations over arrays would be cool, but outside the scope. A similar approach should work for that, but it would be a bit more fiddly, I think.
